### PR TITLE
Slottable and slots

### DIFF
--- a/.changeset/small-apricots-end.md
+++ b/.changeset/small-apricots-end.md
@@ -1,0 +1,5 @@
+---
+'@blockle/blocks': minor
+---
+
+Breaking change: removed polymorphic component renderer and replaced with asChild (inspired by radix ui)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",
-    "@radix-ui/react-polymorphic": "^0.0.14",
     "@vanilla-extract/css": "^1.13.0",
     "@vanilla-extract/css-utils": "^0.1.3",
     "@vanilla-extract/sprinkles": "^1.6.1",

--- a/src/components/Box/Box.spec.tsx
+++ b/src/components/Box/Box.spec.tsx
@@ -8,13 +8,16 @@ describe('Box', () => {
     expect(getByText('Box content')).toBeInTheDocument();
   });
 
-  it('should render Anchor', () => {
+  it('should render Anchor when asChild prop is provided', () => {
     const { getByText } = render(
-      <Box as="a" href="/foo" padding={['small', 'medium', 'large']}>
-        Box content
+      <Box asChild>
+        <a href="/foo">Box content</a>
       </Box>,
     );
 
-    expect(getByText('Box content')).toHaveAttribute('href', '/foo');
+    const target = getByText('Box content');
+
+    expect(target.tagName).toEqual('A');
+    expect(target).toHaveAttribute('href', '/foo');
   });
 });

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -34,5 +34,6 @@ export const Default: StoryObj<BoxProps> = {
   },
   args: {
     children: <a href="#">SOEP</a>,
+    asChild: true,
   },
 };

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -24,16 +24,46 @@ export default {
 } as Meta;
 
 export const Default: StoryObj<BoxProps> = {
-  render: (props) => {
+  render(props) {
     return <Box {...props} />;
   },
-  play: async ({ canvasElement }) => {
+  async play({ canvasElement }) {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText('Box')).toBeInTheDocument();
+    expect(canvas.getByText('Box contents')).toBeInTheDocument();
   },
   args: {
-    children: <a href="#">SOEP</a>,
+    children: 'Box contents',
+  },
+};
+
+export const AsChild: StoryObj<BoxProps> = {
+  render(props) {
+    return <Box {...props} />;
+  },
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+    const link = canvas.getByText('Link text');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://google.com');
+    expect(link.tagName).toEqual('A');
+  },
+  args: {
     asChild: true,
+    color: 'primary',
+    children: (
+      <a
+        href="https://google.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(event) => {
+          event.preventDefault();
+          console.log('Link clicked');
+        }}
+      >
+        Link text
+      </a>
+    ),
   },
 };

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -33,6 +33,6 @@ export const Default: StoryObj<BoxProps> = {
     expect(canvas.getByText('Box')).toBeInTheDocument();
   },
   args: {
-    children: 'Box',
+    children: <a href="#">SOEP</a>,
   },
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,33 +1,31 @@
-import type { ForwardRefComponent } from '@radix-ui/react-polymorphic';
 import { forwardRef } from 'react';
-import { Atoms } from '../../lib/css/atoms';
-import { atoms } from '../../lib/css/atoms/sprinkles.css';
+import { atoms } from '../../lib/css/atoms';
+import { Atoms } from '../../lib/css/atoms/atomTypes';
+import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
-
-const defaultElement = 'div';
+import { createSlot } from '../Slot/Slot';
 
 export type BoxProps = {
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  asChild?: boolean;
 } & Atoms;
 
-type PolymorphicBox = ForwardRefComponent<'div', BoxProps>;
+const Slot = createSlot('div');
 
-export const Box = forwardRef(function Box({ className, as, ...restProps }, ref) {
-  const Component = as || defaultElement;
-  const atomProps: Record<string, unknown> = {};
-  const otherProps: Record<string, unknown> = {};
-
-  for (const [name, value] of Object.entries(restProps)) {
-    if ((atoms.properties as Set<string>).has(name)) {
-      atomProps[name] = value;
-    } else {
-      otherProps[name] = value;
-    }
-  }
+export const Box = forwardRef<any, BoxProps>(function Box(
+  { asChild, className, ...restProps },
+  ref,
+) {
+  const [atomsProps, otherProps] = getAtomsAndProps(restProps);
 
   return (
-    <Component ref={ref} className={classnames(className, atoms(atomProps))} {...otherProps} />
+    <Slot
+      ref={ref}
+      asChild={asChild}
+      className={classnames(className, atoms(atomsProps))}
+      {...otherProps}
+    />
   );
-}) as PolymorphicBox;
+});

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -16,7 +16,7 @@ export type BoxProps = {
 
 const Slottable = createSlottable('div');
 
-export const Box = forwardRef<any, BoxProps>(function Box(
+export const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
   { asChild, className, children, ...restProps },
   ref,
 ) {

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -3,29 +3,33 @@ import { atoms } from '../../lib/css/atoms';
 import { Atoms } from '../../lib/css/atoms/atomTypes';
 import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
-import { createSlot } from '../Slot/Slot';
+import { HTMLElementProps } from '../../lib/utils/utils';
+import { createSlottable } from '../Slot/Slot';
 
 export type BoxProps = {
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
   asChild?: boolean;
-} & Atoms;
+} & Atoms &
+  HTMLElementProps<HTMLDivElement>;
 
-const Slot = createSlot('div');
+const Slottable = createSlottable('div');
 
 export const Box = forwardRef<any, BoxProps>(function Box(
-  { asChild, className, ...restProps },
+  { asChild, className, children, ...restProps },
   ref,
 ) {
   const [atomsProps, otherProps] = getAtomsAndProps(restProps);
 
   return (
-    <Slot
+    <Slottable
       ref={ref}
       asChild={asChild}
       className={classnames(className, atoms(atomsProps))}
       {...otherProps}
-    />
+    >
+      {children}
+    </Slottable>
   );
 });

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -16,7 +16,7 @@ export type BoxProps = {
 
 const Slottable = createSlottable('div');
 
-export const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
+export const Box = forwardRef<unknown, BoxProps>(function Box(
   { asChild, className, children, ...restProps },
   ref,
 ) {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -16,7 +16,8 @@ export const Default: StoryObj<ButtonProps> = {
   },
 
   args: {
-    children: 'Button',
+    // children: 'Button',
+    children: <a href="/">Link</a>,
     onClick: jest.fn(() => {
       console.log('Button clicked');
     }),

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -29,11 +29,15 @@ export const LinkButton: StoryObj<ButtonProps> = {
   },
 
   args: {
-    children: <a href="https://google.com">Link text</a>,
+    children: (
+      <a href="https://google.com" target="_blank" rel="noreferrer">
+        Link text
+      </a>
+    ),
     asChild: true,
     onClick: jest.fn((event) => {
       event.preventDefault();
-      console.log('Link clicked');
+      console.log('Link clicked and default prevented');
     }),
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -16,10 +16,24 @@ export const Default: StoryObj<ButtonProps> = {
   },
 
   args: {
-    // children: 'Button',
-    children: <a href="/">Link</a>,
+    children: 'Button',
     onClick: jest.fn(() => {
       console.log('Button clicked');
+    }),
+  },
+};
+
+export const LinkButton: StoryObj<ButtonProps> = {
+  render: (props) => {
+    return <Button {...props} />;
+  },
+
+  args: {
+    children: <a href="https://google.com">Link text</a>,
+    asChild: true,
+    onClick: jest.fn((event) => {
+      event.preventDefault();
+      console.log('Link clicked');
     }),
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -69,7 +69,7 @@ export const Play: StoryObj<ButtonProps> = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    userEvent.click(canvas.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
 
     expect(args.onClick).toHaveBeenCalled();
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -9,8 +9,6 @@ import { Slot, createSlottable } from '../Slot/Slot';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
 
-const Slottable = createSlottable('button');
-
 export type ButtonProps = {
   children: React.ReactNode;
   type?: 'button' | 'submit' | 'reset';
@@ -26,6 +24,8 @@ export type ButtonProps = {
   asChild?: boolean;
 } & Omit<HTMLElementProps<HTMLButtonElement>, 'size'> &
   MarginAtoms;
+
+const Slottable = createSlottable('button');
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,14 +6,12 @@ import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
 import { Box } from '../Box';
-import { createSlot } from '../Slot/Slot';
+import { SlotChildren, createSlot } from '../Slot/Slot';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
 
 const Slot = createSlot('button');
 
-// TODO How could we render a link variant of the button?
-// Note, it should also work with Link component (next/link, ...)
 export type ButtonProps = {
   children: React.ReactNode;
   type?: 'button' | 'submit' | 'reset';
@@ -33,11 +31,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   {
     children,
     className,
-    // type = 'button',
     variant,
     intent,
     size,
-    // width,
     startSlot,
     endSlot,
     loading,
@@ -71,7 +67,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
       {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
       {loading && <Spinner size={size} marginRight="medium" />}
-      {children}
+      <SlotChildren>{children}</SlotChildren>
       {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
     </Slot>
   );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,8 +5,11 @@ import { ButtonTheme } from '../../lib/theme/componentThemes';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
 import { Box } from '../Box';
+import { createSlot } from '../Slot/Slot';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
+
+const Slot = createSlot('button');
 
 // TODO How could we render a link variant of the button?
 // Note, it should also work with Link component (next/link, ...)
@@ -22,6 +25,7 @@ export type ButtonProps = {
   startSlot?: React.ReactNode;
   endSlot?: React.ReactNode;
   disabled?: boolean;
+  asChild?: boolean;
 } & Omit<HTMLElementProps<HTMLButtonElement>, 'size'>;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
@@ -37,6 +41,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     endSlot,
     loading,
     disabled,
+    asChild,
     ...restProps
   },
   ref,
@@ -55,18 +60,19 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   return (
     <Box
       ref={ref}
-      as="button"
+      asChild
+      // as="button"
       className={classnames(styles.buttonReset, buttonClassName, className)}
       width={width}
-      type={type}
-      disabled={disabled || loading}
       {...restProps}
     >
-      {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
-      {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
-      {loading && <Spinner size={size} marginRight="medium" />}
-      {children}
-      {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
+      <Slot asChild={asChild} type={type} disabled={disabled || loading}>
+        {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
+        {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
+        {loading && <Spinner size={size} marginRight="medium" />}
+        {children}
+        {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
+      </Slot>
     </Box>
   );
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,11 +1,10 @@
 import { forwardRef } from 'react';
 import { useComponentStyles } from '../../hooks/useComponentStyles';
-import { Atoms, atoms } from '../../lib/css/atoms';
+import { Atoms, MarginAtoms, atoms } from '../../lib/css/atoms';
 import { ButtonTheme } from '../../lib/theme/componentThemes';
 import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
-import { Box } from '../Box';
 import { SlotChildren, createSlot } from '../Slot/Slot';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
@@ -25,7 +24,8 @@ export type ButtonProps = {
   endSlot?: React.ReactNode;
   disabled?: boolean;
   asChild?: boolean;
-} & Omit<HTMLElementProps<HTMLButtonElement>, 'size'>;
+} & Omit<HTMLElementProps<HTMLButtonElement>, 'size'> &
+  MarginAtoms;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
@@ -64,11 +64,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       className={classnames(styles.buttonReset, buttonClassName, atoms(atomsProps), className)}
       {...otherProps}
     >
-      {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
-      {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
-      {loading && <Spinner size={size} marginRight="medium" />}
+      {startSlot && <div>{startSlot}</div>}
+      {loading && <Spinner size={size} />}
       <SlotChildren>{children}</SlotChildren>
-      {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
+      {endSlot && <div>{endSlot}</div>}
     </Slot>
   );
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,8 @@
 import { forwardRef } from 'react';
 import { useComponentStyles } from '../../hooks/useComponentStyles';
-import { Atoms } from '../../lib/css/atoms';
+import { Atoms, atoms } from '../../lib/css/atoms';
 import { ButtonTheme } from '../../lib/theme/componentThemes';
+import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
 import { Box } from '../Box';
@@ -32,11 +33,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   {
     children,
     className,
-    type = 'button',
+    // type = 'button',
     variant,
     intent,
     size,
-    width,
+    // width,
     startSlot,
     endSlot,
     loading,
@@ -57,22 +58,21 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     },
   });
 
+  const [atomsProps, otherProps] = getAtomsAndProps(restProps);
+
   return (
-    <Box
+    <Slot
       ref={ref}
-      asChild
-      // as="button"
-      className={classnames(styles.buttonReset, buttonClassName, className)}
-      width={width}
-      {...restProps}
+      asChild={asChild}
+      disabled={disabled || loading}
+      className={classnames(styles.buttonReset, buttonClassName, atoms(atomsProps), className)}
+      {...otherProps}
     >
-      <Slot asChild={asChild} type={type} disabled={disabled || loading}>
-        {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
-        {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
-        {loading && <Spinner size={size} marginRight="medium" />}
-        {children}
-        {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
-      </Slot>
-    </Box>
+      {/* TODO PaddingRight values should not be hardcoded, could wrap children in a div and use gap? */}
+      {startSlot && <Box paddingRight="medium">{startSlot}</Box>}
+      {loading && <Spinner size={size} marginRight="medium" />}
+      {children}
+      {endSlot && <Box paddingLeft="medium">{endSlot}</Box>}
+    </Slot>
   );
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,11 +5,11 @@ import { ButtonTheme } from '../../lib/theme/componentThemes';
 import { getAtomsAndProps } from '../../lib/utils/atom-props';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
-import { SlotChildren, createSlot } from '../Slot/Slot';
+import { Slot, createSlottable } from '../Slot/Slot';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
 
-const Slot = createSlot('button');
+const Slottable = createSlottable('button');
 
 export type ButtonProps = {
   children: React.ReactNode;
@@ -57,7 +57,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const [atomsProps, otherProps] = getAtomsAndProps(restProps);
 
   return (
-    <Slot
+    <Slottable
       ref={ref}
       asChild={asChild}
       disabled={disabled || loading}
@@ -66,8 +66,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     >
       {startSlot && <div>{startSlot}</div>}
       {loading && <Spinner size={size} />}
-      <SlotChildren>{children}</SlotChildren>
+      <Slot>{children}</Slot>
       {endSlot && <div>{endSlot}</div>}
-    </Slot>
+    </Slottable>
   );
 });

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -48,7 +48,7 @@ export const Default: StoryObj<DialogProps> = {
       <>
         <Stack gap="medium">
           <Heading level={2}>Hello world!</Heading>
-          <Text as="p" fontSize="small">
+          <Text tag="p" fontSize="small">
             This is a dialog.
           </Text>
           <NestedDialog>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,5 +1,6 @@
-import { jest } from '@storybook/jest';
+import { expect, jest } from '@storybook/jest';
 import { Meta, StoryObj } from '@storybook/react';
+import { fireEvent, getByRole, userEvent, within } from '@storybook/testing-library';
 import { useState } from 'react';
 import { Button } from '../Button';
 import { Heading } from '../Heading';
@@ -71,21 +72,37 @@ export const Default: StoryObj<DialogProps> = {
   },
 };
 
-// export const Play: StoryObj<DialogProps> = {
-//   render: DialogTemplate,
+export const Play: StoryObj<DialogProps> = {
+  render: DialogTemplate,
 
-//   play: async ({ args, canvasElement }) => {
-//     const canvas = within(canvasElement);
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
 
-//     userEvent.click(canvas.getByRole('Dialog'));
+    // Open dialog
+    await userEvent.click(canvas.getByRole('button', { name: 'Open Dialog' }));
 
-//     expect(args.onClick).toHaveBeenCalled();
-//   },
+    const dialog = getByRole(document.body, 'dialog');
 
-//   args: {
-//     children: 'Dialog',
-//     onClick: jest.fn(() => {
-//       console.log('Dialog clicked');
-//     }),
-//   },
-// };
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(dialog).not.toBeInTheDocument();
+  },
+
+  args: {
+    children: (
+      <>
+        <Stack gap="medium">
+          <Heading level={2}>Hello world</Heading>
+          <Button type="submit">Close Dialog</Button>
+        </Stack>
+      </>
+    ),
+    onRequestClose: jest.fn(() => {
+      console.log('Dialog clicked');
+    }),
+  },
+};

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -102,10 +102,8 @@ export const Dialog: React.FC<DialogProps> = ({
           onClick={onBackdropClick}
           onAnimationEnd={onAnimationEnd}
         >
-          <Box
+          <dialog
             ref={dialogRef}
-            as="dialog"
-            // By default users can not interact with the page when a dialog is open
             aria-modal="true"
             open
             className={classnames(
@@ -117,7 +115,7 @@ export const Dialog: React.FC<DialogProps> = ({
             {...restProps}
           >
             {children}
-          </Box>
+          </dialog>
         </Box>
       </DialogContext.Provider>
     </Portal>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,6 +1,8 @@
 import { Atoms, MarginAndPaddingAtoms } from '../../lib/css/atoms';
+import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
 import { Box } from '../Box';
+import * as styles from './heading.css';
 
 export type HeadingProps = {
   align?: Atoms['textAlign'];
@@ -23,21 +25,19 @@ export const Heading: React.FC<HeadingProps> = ({
   fontFamily,
   ...restProps
 }) => {
-  const as = `h${level}` as const;
+  const Tag = `h${level}` as const;
 
   return (
     <Box
-      as={as}
-      className={className}
+      asChild
+      className={classnames(styles.heading, className)}
       fontFamily={fontFamily}
       fontWeight={fontWeight}
       fontSize={fontSize}
       textAlign={align}
-      padding="none"
-      margin="none"
       {...restProps}
     >
-      {children}
+      <Tag>{children}</Tag>
     </Box>
   );
 };

--- a/src/components/Heading/heading.css.ts
+++ b/src/components/Heading/heading.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+import { blocksLayer } from '../../lib/css/layers/layers.css';
+
+export const heading = style({
+  '@layer': {
+    [blocksLayer]: {
+      margin: 0,
+      padding: 0,
+    },
+  },
+});

--- a/src/components/Inline/Inline.stories.tsx
+++ b/src/components/Inline/Inline.stories.tsx
@@ -1,8 +1,8 @@
 import { expect } from '@storybook/jest';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
-import { Inline, InlineProps } from './Inline';
 import { vars } from '../../lib/theme/vars.css';
+import { Inline, InlineProps } from './Inline';
 
 export default {
   title: 'Layout/Inline',
@@ -75,6 +75,6 @@ export const List: StoryObj<InlineProps> = {
         <li style={{ border: '1px red solid', width: '60px', height: '60px' }}>3</li>
       </>
     ),
-    as: 'ol',
+    tag: 'ol',
   },
 };

--- a/src/components/Inline/Inline.tsx
+++ b/src/components/Inline/Inline.tsx
@@ -10,7 +10,7 @@ import { Box } from '../Box/Box';
 export type InlineProps = {
   alignX?: keyof JustifyContentMap;
   alignY?: keyof AlignItemsMap;
-  as?: 'div' | 'ul' | 'ol' | 'nav';
+  tag?: 'div' | 'ul' | 'ol' | 'nav';
   children: React.ReactNode;
   className?: string;
   display?: ResponsiveDisplayFlex;
@@ -21,14 +21,12 @@ export type InlineProps = {
 export const Inline: React.FC<InlineProps> = ({
   alignX,
   alignY,
-  as = 'div',
+  tag: Tag = 'div',
   children,
   display = 'flex',
   gap,
   ...props
 }) => {
-  const Tag = as;
-
   return (
     <Box
       asChild

--- a/src/components/Inline/Inline.tsx
+++ b/src/components/Inline/Inline.tsx
@@ -27,9 +27,11 @@ export const Inline: React.FC<InlineProps> = ({
   gap,
   ...props
 }) => {
+  const Tag = as;
+
   return (
     <Box
-      as={as}
+      asChild
       display={display}
       gap={gap}
       flexDirection="row"
@@ -38,7 +40,7 @@ export const Inline: React.FC<InlineProps> = ({
       flexWrap="wrap"
       {...props}
     >
-      {children}
+      <Tag>{children}</Tag>
     </Box>
   );
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -30,18 +30,17 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       <Box display="flex" alignItems="center" className={classnames(containerClassName, className)}>
         {startSlot}
 
-        <Box
-          as="input"
-          id={id}
-          ref={ref}
-          name={name}
-          type={type}
-          placeholder={placeholder || label}
-          width="full"
-          overflow="hidden"
-          className={classnames(styles.input, inputClassName)}
-          {...restProps}
-        />
+        <Box asChild width="full" overflow="hidden">
+          <input
+            id={id}
+            ref={ref}
+            name={name}
+            type={type}
+            placeholder={placeholder || label}
+            className={classnames(styles.input, inputClassName)}
+            {...restProps}
+          />
+        </Box>
 
         {endSlot}
       </Box>

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -25,6 +25,7 @@ export const Default: StoryObj<LinkProps> = {
   args: {
     children: 'Link',
     href: 'https://example.com',
+    underline: true,
     onClick: jest.fn(() => {
       console.log('Link clicked');
     }),
@@ -39,7 +40,7 @@ export const Play: StoryObj<LinkProps> = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    userEvent.click(canvas.getByRole('Link'));
+    await userEvent.click(canvas.getByRole('link'));
 
     expect(args.onClick).toHaveBeenCalled();
   },
@@ -47,7 +48,10 @@ export const Play: StoryObj<LinkProps> = {
   args: {
     children: 'Link',
     href: 'https://example.com',
-    onClick: jest.fn(() => {
+    underline: true,
+    onClick: jest.fn((event) => {
+      event.preventDefault();
+
       console.log('Link clicked');
     }),
   },

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,34 +1,38 @@
-import { ForwardRefComponent } from '@radix-ui/react-polymorphic';
 import { forwardRef } from 'react';
 import { useComponentStyles } from '../../hooks/useComponentStyles';
 import { Atoms } from '../../lib/css/atoms';
 import { LinkTheme } from '../../lib/theme/componentThemes';
 import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
-import { Box } from '../Box';
-
-const defaultElement = 'a';
+import { createSlottable } from '../Slot/Slot';
 
 export type LinkProps = {
+  asChild?: boolean;
   children?: React.ReactNode;
   underline?: LinkTheme['variants']['underline'];
   variant?: LinkTheme['variants']['variant'];
 } & Atoms &
   HTMLElementProps<HTMLAnchorElement>;
 
-type PolymorphicLink = ForwardRefComponent<'a', LinkProps>;
+const Slottable = createSlottable('a');
 
-export const Link = forwardRef(function Link(
-  { as, className, variant, underline, ...restProps },
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { asChild, className, children, variant, underline, ...restProps },
   ref,
 ) {
-  const Component = as || defaultElement;
   const linkClassName = useComponentStyles('link', {
     base: true,
     variants: { variant, underline },
   });
 
   return (
-    <Box ref={ref} as={Component} className={classnames(className, linkClassName)} {...restProps} />
+    <Slottable
+      asChild={asChild}
+      ref={ref}
+      className={classnames(className, linkClassName)}
+      {...restProps}
+    >
+      {children}
+    </Slottable>
   );
-}) as PolymorphicLink;
+});

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -13,7 +13,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   ...restProps
 }) => {
   return (
-    <Stack as="div" role="radiogroup" gap={gap} {...restProps}>
+    <Stack tag="div" role="radiogroup" gap={gap} {...restProps}>
       {children}
     </Stack>
   );

--- a/src/components/Slot/Slot.tsx
+++ b/src/components/Slot/Slot.tsx
@@ -3,7 +3,7 @@ import React, { Children, cloneElement, forwardRef, isValidElement } from 'react
 import { composeRefs } from '../../lib/react/react';
 import { UknownRecord, mergeProps } from './mergeProps';
 
-type HTMLElementTags = 'a' | 'button' | 'div';
+type HTMLElementTags = 'a' | 'button' | 'div' | 'span';
 
 // Cases 1: No SlotChildren, direct descendant
 // const Slot = createSlot('div');

--- a/src/components/Slot/Slot.tsx
+++ b/src/components/Slot/Slot.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { Children, cloneElement, forwardRef, isValidElement, useRef } from 'react';
+
+type HTMLElementTags = 'div' | 'span' | 'button';
+
+type UknownRecord = Record<string, unknown>;
+
+export function createSlot<const E extends HTMLElementTags>(defaultElement: E) {
+  type SlotProps = { asChild?: boolean } & React.HTMLProps<React.ElementRef<E>>;
+
+  function Slot(props: SlotProps, ref?: React.ForwardedRef<any>): React.ReactElement | null {
+    const { asChild, children, ...restProps } = props;
+    const Component = defaultElement as HTMLElementTags;
+
+    // Return default element
+    if (!asChild) {
+      return (
+        <Component ref={ref} {...(restProps as UknownRecord)}>
+          {children}
+        </Component>
+      );
+    }
+
+    const childrenArray = Children.toArray(children);
+    const firstChild = childrenArray[0];
+
+    if (childrenArray.length === 0) {
+      throw new Error('Expect one child');
+    }
+
+    if (childrenArray.length > 1) {
+      throw new Error('Expect one element with prop `asChild`');
+    }
+
+    if (!isValidElement(firstChild)) {
+      throw new Error('Provide a valid react element');
+    }
+
+    const { children: subChildren, ...restProps2 } = firstChild.props;
+
+    // Merge refs
+    // Merge props
+    // - Special cases: classNames, functions
+
+    console.log({
+      ...restProps,
+      ...restProps2,
+    });
+
+    return cloneElement(
+      firstChild,
+      {
+        ...restProps,
+        ...restProps2,
+      },
+      subChildren,
+    );
+  }
+
+  return forwardRef<any, SlotProps>(Slot) as (
+    props: SlotProps,
+    ref: React.ForwardedRef<any>,
+  ) => ReturnType<typeof Slot>;
+}
+
+// Example
+
+const MySlot = createSlot('div');
+
+export const XX2: React.FC = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <MySlot
+      asChild
+      ref={ref}
+      onClick={(event) => {
+        event.preventDefault();
+        console.log(event);
+      }}
+    >
+      <a href="/">Link yooo 1</a>
+    </MySlot>
+  );
+};

--- a/src/components/Slot/Slot.tsx
+++ b/src/components/Slot/Slot.tsx
@@ -3,7 +3,8 @@ import React, { Children, cloneElement, forwardRef, isValidElement } from 'react
 import { composeRefs } from '../../lib/react/react';
 import { UknownRecord, mergeProps } from './mergeProps';
 
-type HTMLElementTags = 'a' | 'button' | 'div' | 'span';
+// Subset of HTML element tags that can be used as a default element
+type HTMLElementTags = 'a' | 'article' | 'button' | 'div' | 'p' | 'section' | 'span' | 'strong';
 
 // Cases 1: No SlotChildren, direct descendant
 // const Slot = createSlot('div');

--- a/src/components/Slot/Slot.tsx
+++ b/src/components/Slot/Slot.tsx
@@ -57,6 +57,14 @@ export function createSlottable<E extends HTMLElementTags>(defaultElement: E) {
     if (!slot) {
       const Slot = childrenArray[0] as React.FunctionComponentElement<any>;
 
+      if (!isValidElement(childrenArray[0])) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('Slottable: First child is not a valid React element');
+        }
+
+        return null;
+      }
+
       if (!isValidElement(Slot)) {
         return null;
       }

--- a/src/components/Slot/index.ts
+++ b/src/components/Slot/index.ts
@@ -1,0 +1,1 @@
+export { Slot, createSlottable } from './Slot';

--- a/src/components/Slot/mergeProps.ts
+++ b/src/components/Slot/mergeProps.ts
@@ -1,0 +1,34 @@
+export type UknownRecord = Record<string, unknown>;
+
+export function mergeProps(slotProps: UknownRecord, childProps: UknownRecord) {
+  const overrideProps: UknownRecord = {};
+
+  for (const propName in childProps) {
+    const slotPropValue = slotProps[propName];
+    const childPropValue = childProps[propName];
+
+    if (childPropValue === undefined) {
+      continue;
+    }
+
+    if (slotPropValue === undefined) {
+      overrideProps[propName] = childPropValue;
+      continue;
+    }
+
+    if (typeof slotPropValue === 'function' && typeof childPropValue === 'function') {
+      overrideProps[propName] = (...args: unknown[]) => {
+        childPropValue(...args);
+        slotPropValue(...args);
+      };
+    } else if (propName === 'style') {
+      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
+    } else if (propName === 'className') {
+      overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+    } else {
+      overrideProps[propName] = childPropValue;
+    }
+  }
+
+  return { ...slotProps, ...overrideProps };
+}

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -1,9 +1,9 @@
 import { expect } from '@storybook/jest';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
+import { vars } from '../../lib/theme/vars.css';
 import { Box } from '../Box';
 import { Stack, StackProps } from './Stack';
-import { vars } from '../../lib/theme/vars.css';
 
 export default {
   title: 'Layout/Stack',
@@ -67,7 +67,7 @@ export const List: StoryObj<StackProps> = {
 
   args: {
     gap: ['small', 'medium', 'large'],
-    as: 'ol',
+    tag: 'ol',
     children: (
       <>
         <li>1</li>

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -4,7 +4,7 @@ import { Box } from '../Box/Box';
 
 export type StackProps = {
   alignX?: keyof AlignItemsMap;
-  as?: 'div' | 'section' | 'ul' | 'ol';
+  tag?: 'div' | 'section' | 'ul' | 'ol';
   children: React.ReactNode;
   className?: string;
   display?: ResponsiveDisplayFlex;
@@ -12,24 +12,22 @@ export type StackProps = {
   style?: React.CSSProperties;
   role?: React.AriaRole;
   /**
-   * Start prop is only valid when as="ol"
+   * Start prop is only valid when tag="ol"
    */
   start?: number;
 } & MarginAndPaddingAtoms;
 
 export const Stack: React.FC<StackProps> = ({
-  as = 'div',
+  tag: Tag = 'div',
   display = 'flex',
   children,
   gap,
   alignX,
   ...restProps
 }) => {
-  if (process.env.NODE_ENV === 'development' && restProps.start !== undefined && as !== 'ol') {
-    console.warn('Stack: start prop is only valid when as="ol"');
+  if (process.env.NODE_ENV === 'development' && restProps.start !== undefined && Tag !== 'ol') {
+    console.warn('Stack: start prop is only valid when tag="ol"');
   }
-
-  const Tag = as;
 
   return (
     <Box

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -29,16 +29,18 @@ export const Stack: React.FC<StackProps> = ({
     console.warn('Stack: start prop is only valid when as="ol"');
   }
 
+  const Tag = as;
+
   return (
     <Box
-      as={as}
+      asChild
       display={display}
       gap={gap}
       flexDirection="column"
       alignItems={alignX ? alignItemsMap[alignX] : undefined}
       {...restProps}
     >
-      {children}
+      <Tag>{children}</Tag>
     </Box>
   );
 };

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -2,8 +2,8 @@ import { expect } from '@storybook/jest';
 import { Meta, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
 import { responsiveProperties, unresponsiveProperties } from '../../lib/css/atoms/atomicProperties';
-import { Text, TextProps } from './Text';
 import { vars } from '../../lib/theme/vars.css';
+import { Text, TextProps } from './Text';
 
 export default {
   title: 'Typography/Text',
@@ -47,6 +47,6 @@ export const Default: StoryObj<TextProps> = {
   args: {
     children: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
     fontFamily: 'primary',
-    as: 'span',
+    tag: 'span',
   },
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,7 +7,7 @@ import * as styles from './text.css';
 
 export type TextProps = {
   children: React.ReactNode;
-  as?: 'span' | 'p' | 'strong' | 'em' | 'small' | 's' | 'del' | 'ins' | 'sub' | 'sup';
+  tag?: 'span' | 'p' | 'strong' | 'em' | 'small' | 's' | 'del' | 'ins' | 'sub' | 'sup';
   asChild?: boolean;
   color?: Atoms['color'];
   fontSize?: Atoms['fontSize'];
@@ -25,7 +25,7 @@ export type TextProps = {
 
 export const Text: React.FC<TextProps> = forwardRef<HTMLSpanElement, TextProps>(function Text(
   {
-    as = 'span',
+    tag: Tag = 'span',
     asChild,
     children,
     color,
@@ -38,8 +38,6 @@ export const Text: React.FC<TextProps> = forwardRef<HTMLSpanElement, TextProps>(
   },
   ref,
 ) {
-  const Tag = as;
-
   return (
     <Box
       ref={ref}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,10 +1,14 @@
+import { forwardRef } from 'react';
 import { Atoms, MarginAndPaddingAtoms } from '../../lib/css/atoms';
+import { classnames } from '../../lib/utils/classnames';
 import { HTMLElementProps } from '../../lib/utils/utils';
 import { Box } from '../Box/Box';
+import * as styles from './text.css';
 
 export type TextProps = {
   children: React.ReactNode;
   as?: 'span' | 'p' | 'strong' | 'em' | 'small' | 's' | 'del' | 'ins' | 'sub' | 'sup';
+  asChild?: boolean;
   color?: Atoms['color'];
   fontSize?: Atoms['fontSize'];
   fontWeight?: Atoms['fontWeight'];
@@ -19,29 +23,36 @@ export type TextProps = {
 } & MarginAndPaddingAtoms &
   HTMLElementProps<HTMLSpanElement>;
 
-export const Text: React.FC<TextProps> = ({
-  as = 'span',
-  children,
-  color,
-  fontSize,
-  fontWeight,
-  fontFamily,
-  textAlign,
-  ...restProps
-}) => {
+export const Text: React.FC<TextProps> = forwardRef<HTMLSpanElement, TextProps>(function Text(
+  {
+    as = 'span',
+    asChild,
+    children,
+    color,
+    fontSize,
+    fontWeight,
+    fontFamily,
+    textAlign,
+    className,
+    ...restProps
+  },
+  ref,
+) {
+  const Tag = as;
+
   return (
     <Box
-      as={as}
+      ref={ref}
+      asChild
       color={color}
       fontSize={fontSize}
       fontWeight={fontWeight}
       fontFamily={fontFamily}
       textAlign={textAlign}
-      padding="none"
-      margin="none"
+      className={classnames(styles.text, className)}
       {...restProps}
     >
-      {children}
+      {asChild ? children : <Tag>{children}</Tag>}
     </Box>
   );
-};
+});

--- a/src/components/Text/text.css.ts
+++ b/src/components/Text/text.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+import { blocksLayer } from '../../lib/css/layers/layers.css';
+
+export const text = style({
+  '@layer': {
+    [blocksLayer]: {
+      margin: 0,
+      padding: 0,
+    },
+  },
+});

--- a/src/hooks/useComponentStyles/useComponentStyles.ts
+++ b/src/hooks/useComponentStyles/useComponentStyles.ts
@@ -57,7 +57,7 @@ export function useComponentStyles<T extends keyof ComponentThemesProps>(
   for (const key of keys) {
     const value = variantsWithDefaults[key as string];
 
-    if (value === undefined) {
+    if (value === undefined || componentVariants[key] === undefined) {
       continue;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ export { Spinner, type SpinnerProps } from './components/Spinner';
 export { Stack, type StackProps } from './components/Stack';
 export { Text, type TextProps } from './components/Text';
 
+// Slot
+export { Slot, createSlottable } from './components/Slot';
+
 // Hooks
 export { useComponentStyleDefaultProps, useComponentStyles } from './hooks/useComponentStyles';
 

--- a/src/lib/react/react.ts
+++ b/src/lib/react/react.ts
@@ -1,0 +1,17 @@
+type PossibleRef<T> = React.Ref<T> | undefined | unknown;
+
+function setRef<T>(ref: PossibleRef<T>, value: T) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref !== null && ref !== undefined) {
+    (ref as React.MutableRefObject<T>).current = value;
+  }
+}
+
+export function composeRefs<T>(...refs: PossibleRef<T>[]) {
+  return (node: T) => {
+    for (const ref of refs) {
+      setRef(ref, node);
+    }
+  };
+}

--- a/src/lib/utils/atom-props.ts
+++ b/src/lib/utils/atom-props.ts
@@ -1,0 +1,21 @@
+import { atoms } from '../css/atoms/sprinkles.css';
+
+/**
+ *
+ */
+export function getAtomsAndProps(
+  props: Record<string, unknown>,
+): [atomsClassNames: Record<string, unknown>, props: Record<string, unknown>] {
+  const atomProps: Record<string, unknown> = {};
+  const otherProps: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(props)) {
+    if ((atoms.properties as Set<string>).has(name)) {
+      atomProps[name] = value;
+    } else {
+      otherProps[name] = value;
+    }
+  }
+
+  return [atomProps, otherProps];
+}

--- a/src/themes/momotaro/components/button.css.ts
+++ b/src/themes/momotaro/components/button.css.ts
@@ -14,6 +14,8 @@ export const button = makeComponentTheme('button', {
       fontSize: 'medium',
       borderRadius: 'medium',
       fontWeight: 'medium',
+      // Space between icon and text
+      gap: 'small',
     }),
     clickable,
   ]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,11 +2012,6 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
 
-"@radix-ui/react-polymorphic@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.14.tgz#fc6cefee6686db8c5a7ff14c8c1b9b5abdee325b"
-  integrity sha512-9nsMZEDU3LeIUeHJrpkkhZVxu/9Fc7P2g2I3WR+uA9mTbNC3hGaabi0dV6wg0CfHb+m4nSs1pejbE/5no3MJTA==
-
 "@radix-ui/react-popper@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.2.tgz#4c0b96fcd188dc1f334e02dba2d538973ad842e9"


### PR DESCRIPTION
Removed polymorphic ts on component in favour of asChild implementation.

`asChild` replaces the default element of Slottable with the first child passed to it.

```tsx
<Button asChild>
  <a href="/">Link text</a>
</Button>

// output:
// <a href="/" className="styling-from-Button-...">Link text</a>
```

Slottable usage:

```tsx
// Create slottable with default element
const Slottable = createSlottable('button');

const Button = forwardRef(function Button({ asChild, children, ...restProps }) {
  return (
    <Slottable asChild={asChild}>
      <div>Component markup</div>
      <Slot>{children}</Slot>
    </Slottable>
  )
})
```