### PR TITLE
Dialog update

### DIFF
--- a/.changeset/large-elephants-shave.md
+++ b/.changeset/large-elephants-shave.md
@@ -1,0 +1,5 @@
+---
+'@blockle/blocks': patch
+---
+
+Dialog support for "prefers-reduced-motion"

--- a/src/components/Dialog/dialog.css.ts
+++ b/src/components/Dialog/dialog.css.ts
@@ -1,93 +1,18 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { blocksLayer } from '../../lib/css/layers/layers.css';
-
-export const backdropEnterAnimation = keyframes({
-  '0%': {
-    opacity: 0,
-  },
-  '100%': {
-    opacity: 1,
-  },
-});
-
-export const backdropLeaveAnimation = keyframes({
-  '0%': {
-    opacity: 1,
-  },
-  '100%': {
-    opacity: 0,
-  },
-});
-
-export const dialogEnterAnimation = keyframes({
-  '0%': {
-    transform: 'translateY(-20px)',
-  },
-  '100%': {
-    transform: 'translateY(0)',
-  },
-});
-
-export const dialogLeaveAnimation = keyframes({
-  '0%': {
-    transform: 'translateY(0)',
-  },
-  '100%': {
-    transform: 'translateY(-20px)',
-  },
-});
 
 export const backdrop = style({
   '@layer': {
     [blocksLayer]: {
       contain: 'layout',
+      display: 'flex',
+      placeItems: 'center',
       position: 'fixed',
       width: '100%',
       height: '100%',
       left: 0,
       top: 0,
       overflow: 'hidden',
-      opacity: '0',
-      animationName: backdropEnterAnimation,
-      // Js listens to animation event, so by default it the animation is 1ms
-      animationDuration: '1ms',
-      animationFillMode: 'both',
-      '@media': {
-        '(prefers-reduced-motion: no-preference)': {
-          animationDuration: '100ms',
-        },
-      },
-    },
-  },
-});
-
-export const backdropLeave = style({
-  '@layer': {
-    [blocksLayer]: {
-      animationName: backdropLeaveAnimation,
-    },
-  },
-});
-
-export const dialog = style({
-  '@layer': {
-    [blocksLayer]: {
-      animationName: dialogEnterAnimation,
-      animationDuration: '1ms',
-      animationFillMode: 'forwards',
-      '@media': {
-        '(prefers-reduced-motion: no-preference)': {
-          animationDuration: '160ms',
-        },
-      },
-    },
-  },
-});
-
-export const dialogLeave = style({
-  '@layer': {
-    [blocksLayer]: {
-      animationName: dialogLeaveAnimation,
     },
   },
 });

--- a/src/hooks/useKeyboard/index.ts
+++ b/src/hooks/useKeyboard/index.ts
@@ -1,0 +1,1 @@
+export { useKeyboard } from './useKeyboard';

--- a/src/hooks/useKeyboard/useKeyboard.ts
+++ b/src/hooks/useKeyboard/useKeyboard.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+type UseKeyboardOptions = {
+  enabled?: boolean;
+  type?: 'keydown' | 'keyup';
+};
+
+export const useKeyboard = (
+  key: string,
+  callback: () => void,
+  { enabled = true, type = 'keydown' }: UseKeyboardOptions = {},
+) => {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === key) {
+        callback();
+      }
+    }
+
+    document.addEventListener(type, handleKeyDown);
+
+    return () => {
+      document.removeEventListener(type, handleKeyDown);
+    };
+  }, [callback, enabled, key, type]);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ export { Slot, createSlottable } from './components/Slot';
 
 // Hooks
 export { useComponentStyleDefaultProps, useComponentStyles } from './hooks/useComponentStyles';
+export { useIsomorphicLayoutEffect } from './hooks/useIsomorphicLayoutEffect';
+export { useKeyboard } from './hooks/useKeyboard';
+export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 
 // Utils
 export { classnames } from './lib/utils/classnames';

--- a/src/lib/theme/componentThemes.ts
+++ b/src/lib/theme/componentThemes.ts
@@ -36,8 +36,8 @@ export type DividerTheme = {
 };
 
 export type DialogTheme = {
-  base: string;
   backdrop: string;
+  dialog: string;
   variants: {
     size: 'small' | 'medium' | 'large';
   };

--- a/src/lib/utils/dom.ts
+++ b/src/lib/utils/dom.ts
@@ -1,0 +1,11 @@
+/**
+ * Check if the element has animation duration.
+ */
+export function hasAnimationDuration(element: HTMLElement | null): boolean {
+  if (!element) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element);
+  return style.transitionDuration !== '0s' || style.animationDuration !== '0s';
+}

--- a/src/themes/momotaro/components/dialog.css.ts
+++ b/src/themes/momotaro/components/dialog.css.ts
@@ -3,7 +3,7 @@ import { atoms } from '../../../lib/css/atoms';
 import { makeComponentTheme } from '../../../lib/theme/makeComponentTheme';
 
 export const dialog = makeComponentTheme('dialog', {
-  base: style([
+  dialog: style([
     atoms({
       display: 'flex',
       flexDirection: 'column',
@@ -15,10 +15,34 @@ export const dialog = makeComponentTheme('dialog', {
     }),
     {
       minWidth: '300px',
+      selectors: {
+        '&[data-open]': {
+          transform: 'scale(1)',
+        },
+      },
+      // Apply the animation only if the user has not requested reduced motion
+      '@media': {
+        '(prefers-reduced-motion: no-preference)': {
+          transform: 'scale(0.9)',
+          transition: 'transform 160ms',
+        },
+      },
     },
   ]),
   backdrop: style({
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    selectors: {
+      '&[data-open]': {
+        opacity: 1,
+      },
+    },
+    // Apply the animation only if the user has not requested reduced motion
+    '@media': {
+      '(prefers-reduced-motion: no-preference)': {
+        opacity: 0,
+        transition: 'opacity 160ms',
+      },
+    },
   }),
   variants: {
     size: {


### PR DESCRIPTION
Removed the hard coded dialog animations. They can now be defined in the
component theme, by using the selector "[data-open]". Also added support
to define transitions instead of animations.

Added useKeyboard hook.

Renamed dialog component theme prop `base` to `dialog` to better reflects its purpose
