### PR TITLE
Custom style api as a drop-in replacement for vanilla extract style function

### DIFF
--- a/.changeset/thick-cars-sin.md
+++ b/.changeset/thick-cars-sin.md
@@ -1,0 +1,5 @@
+---
+'@blockle/blocks': patch
+---
+
+Custom style api, combines atoms and raw css in a single object with the same api as style. So it could be used as a drop-in replacement for vanilla-extract style function.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Theming and styling
 export { atoms } from './lib/css/atoms/atoms';
 export { breakpointQuery } from './lib/css/atoms/breakpoints';
+export { style } from './lib/css/style/style';
 export { makeComponentTheme, type ThemeComponentsStyles } from './lib/theme/makeComponentTheme';
 export { makeTheme } from './lib/theme/makeTheme';
 export { type ThemeTokens } from './lib/theme/tokensType';

--- a/src/lib/css/style/style.ts
+++ b/src/lib/css/style/style.ts
@@ -1,0 +1,52 @@
+import { StyleRule, style as vanillaExtractStyle } from '@vanilla-extract/css';
+import { Atoms, atoms } from '../atoms';
+
+type ComplexStyleRuleWithAtoms = Omit<StyleRule, keyof Atoms> & {
+  [K in keyof Atoms]?: K extends keyof StyleRule
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      Atoms[K] | (string & {}) | number // Could type it as: Atoms[K] | StyleRule[K]
+    : Atoms[K];
+};
+
+export function style(
+  props: ComplexStyleRuleWithAtoms | (ComplexStyleRuleWithAtoms | string)[],
+): string {
+  const styleRule: Record<string, unknown> = {};
+  // const atomsValue: Record<string, unknown> = {};
+  const atomClassNames: string[] = [];
+
+  if (Array.isArray(props)) {
+    // eslint-disable-next-line unicorn/no-array-callback-reference
+    return props
+      .map((rule) => {
+        if (typeof rule === 'string') {
+          return rule;
+        }
+
+        return style(rule);
+      })
+      .join(' ');
+  }
+
+  for (const [name, value] of Object.entries(props)) {
+    if ((atoms.properties as Set<string>).has(name)) {
+      // atoms function throws an error if the value is not valid
+      // So use this to fallback to raw CSS values
+      // It would be nice to have a function that checks if a value is valid
+      // But since this is code runs at build time, we don't care about performance
+      // Something like:
+      // atoms.isValidValue('background', value);
+      // atoms.isValidValue(name, value);
+
+      try {
+        atomClassNames.push(atoms({ [name]: value }));
+      } catch {
+        styleRule[name] = value;
+      }
+    } else {
+      styleRule[name] = value;
+    }
+  }
+
+  return vanillaExtractStyle([styleRule, ...atomClassNames]);
+}

--- a/src/lib/css/style/style.ts
+++ b/src/lib/css/style/style.ts
@@ -1,13 +1,15 @@
 import { StyleRule, style as vanillaExtractStyle } from '@vanilla-extract/css';
+import { AnyString } from '../../utils/helpers';
 import { Atoms, atoms } from '../atoms';
 
 type StyleRuleWithAtoms = Omit<StyleRule, keyof Atoms> & {
-  [K in keyof Atoms]?: K extends keyof StyleRule
-    ? // eslint-disable-next-line @typescript-eslint/ban-types
-      Atoms[K] | (string & {}) | number // Could type it as: Atoms[K] | StyleRule[K]
-    : Atoms[K];
+  [K in keyof Atoms]?: K extends keyof StyleRule ? Atoms[K] | AnyString | number : Atoms[K];
 };
 
+/**
+ * A wrapper around vanilla-extract's `style` function that allows you to use
+ * atoms and raw CSS values in the same object.
+ */
 export function style(props: StyleRuleWithAtoms | (StyleRuleWithAtoms | string)[]): string {
   const styleRule: Record<string, unknown> = {};
   const atomClassNames: string[] = [];
@@ -27,7 +29,7 @@ export function style(props: StyleRuleWithAtoms | (StyleRuleWithAtoms | string)[
   for (const [name, value] of Object.entries(props)) {
     if ((atoms.properties as Set<string>).has(name)) {
       // atoms function throws an error if the value is not valid
-      // So use try/catch to fallback to raw CSS values
+      // So use try/catch to fallback to raw CSS values when atoms throws
 
       try {
         atomClassNames.push(atoms({ [name]: value }));

--- a/src/lib/css/style/style.ts
+++ b/src/lib/css/style/style.ts
@@ -1,22 +1,18 @@
 import { StyleRule, style as vanillaExtractStyle } from '@vanilla-extract/css';
 import { Atoms, atoms } from '../atoms';
 
-type ComplexStyleRuleWithAtoms = Omit<StyleRule, keyof Atoms> & {
+type StyleRuleWithAtoms = Omit<StyleRule, keyof Atoms> & {
   [K in keyof Atoms]?: K extends keyof StyleRule
     ? // eslint-disable-next-line @typescript-eslint/ban-types
       Atoms[K] | (string & {}) | number // Could type it as: Atoms[K] | StyleRule[K]
     : Atoms[K];
 };
 
-export function style(
-  props: ComplexStyleRuleWithAtoms | (ComplexStyleRuleWithAtoms | string)[],
-): string {
+export function style(props: StyleRuleWithAtoms | (StyleRuleWithAtoms | string)[]): string {
   const styleRule: Record<string, unknown> = {};
-  // const atomsValue: Record<string, unknown> = {};
   const atomClassNames: string[] = [];
 
   if (Array.isArray(props)) {
-    // eslint-disable-next-line unicorn/no-array-callback-reference
     return props
       .map((rule) => {
         if (typeof rule === 'string') {
@@ -31,12 +27,7 @@ export function style(
   for (const [name, value] of Object.entries(props)) {
     if ((atoms.properties as Set<string>).has(name)) {
       // atoms function throws an error if the value is not valid
-      // So use this to fallback to raw CSS values
-      // It would be nice to have a function that checks if a value is valid
-      // But since this is code runs at build time, we don't care about performance
-      // Something like:
-      // atoms.isValidValue('background', value);
-      // atoms.isValidValue(name, value);
+      // So use try/catch to fallback to raw CSS values
 
       try {
         atomClassNames.push(atoms({ [name]: value }));

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
+export type AnyString = string & {};
+
 /**
  * Suggest a type for a string literal but also allow any string.
  */
-export type OptionalLiteral<T extends string> = T | (string & {});
+export type OptionalLiteral<T extends string> = T | AnyString;
 
 export type RecordLike = Record<string | number, unknown>;
 

--- a/src/themes/momotaro/components/button.css.ts
+++ b/src/themes/momotaro/components/button.css.ts
@@ -1,5 +1,4 @@
 import { createVar } from '@vanilla-extract/css';
-import { atoms } from '../../../lib/css/atoms';
 import { style } from '../../../lib/css/style/style';
 import { makeComponentTheme } from '../../../lib/theme/makeComponentTheme';
 import { vars } from '../../../lib/theme/vars.css';
@@ -55,30 +54,18 @@ export const button = makeComponentTheme('button', {
       }),
     },
     size: {
-      small: style([
-        atoms({
-          paddingX: 'large',
-        }),
-        {
-          height: 40,
-        },
-      ]),
-      medium: style([
-        atoms({
-          paddingX: 'xlarge',
-        }),
-        {
-          height: 56,
-        },
-      ]),
-      large: style([
-        atoms({
-          paddingX: 'xlarge',
-        }),
-        {
-          height: 72,
-        },
-      ]),
+      small: style({
+        paddingX: 'large',
+        height: 40,
+      }),
+      medium: style({
+        paddingX: 'xlarge',
+        height: 56,
+      }),
+      large: style({
+        paddingX: 'xlarge',
+        height: 72,
+      }),
     },
     intent: {
       neutral: style({

--- a/src/themes/momotaro/components/button.css.ts
+++ b/src/themes/momotaro/components/button.css.ts
@@ -1,5 +1,6 @@
-import { createVar, style } from '@vanilla-extract/css';
+import { createVar } from '@vanilla-extract/css';
 import { atoms } from '../../../lib/css/atoms';
+import { style } from '../../../lib/css/style/style';
 import { makeComponentTheme } from '../../../lib/theme/makeComponentTheme';
 import { vars } from '../../../lib/theme/vars.css';
 import { clickable } from './helpers.css';
@@ -8,15 +9,15 @@ const primaryColor = createVar();
 
 export const button = makeComponentTheme('button', {
   base: style([
-    atoms({
+    {
       display: 'inline-flex',
       placeItems: 'center',
       fontSize: 'medium',
       borderRadius: 'medium',
       fontWeight: 'medium',
-      // Space between `startSlot | text | endSlot`
+      // Space between `startSlot | children | endSlot`
       gap: 'small',
-    }),
+    },
     clickable,
   ]),
   variants: {


### PR DESCRIPTION
Custom style api, combines atoms and raw css in a single object with the same api as style. So it could be used as a drop-in replacement.