### PR TITLE
Renamed props

### DIFF
--- a/.changeset/friendly-cats-hope.md
+++ b/.changeset/friendly-cats-hope.md
@@ -1,0 +1,7 @@
+---
+'@blockle/blocks': patch
+---
+
+- Renamed prop `gap` to `spacing` in Stack
+- Renamed prop `visualOnly` to `asSpan` in Label
+- Removed Stack from RadioGroup for more flexibility how to render child elements

--- a/src/components/feedback/Progress/Progress.stories.tsx
+++ b/src/components/feedback/Progress/Progress.stories.tsx
@@ -20,7 +20,7 @@ export default {
 export const Default: StoryObj<ProgressProps> = {
   render: (props) => {
     return (
-      <Stack gap="medium">
+      <Stack spacing="medium">
         <Text tag="label" id={props['aria-labelledby']}>
           Progress{' '}
           {props.value === undefined ? (

--- a/src/components/form/Checkbox/Checkbox.tsx
+++ b/src/components/form/Checkbox/Checkbox.tsx
@@ -34,7 +34,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
     <label className={labelClassName}>
       {input}
       {label && (
-        <Label visualOnly required={required}>
+        <Label asSpan required={required}>
           {label}
         </Label>
       )}

--- a/src/components/form/Label/Label.tsx
+++ b/src/components/form/Label/Label.tsx
@@ -5,7 +5,13 @@ import { classnames } from '../../../lib/utils/classnames';
 import { HTMLElementProps } from '../../../lib/utils/utils';
 
 export type LabelProps = {
-  visualOnly?: boolean;
+  /**
+   * If true, the label will be rendered as a span element
+   * but will still have the same styles as a label.
+   * Useful for when you want to use a label element but
+   * can't because of the parent element's structure.
+   */
+  asSpan?: boolean;
   htmlFor?: string;
   children?: React.ReactNode;
   required?: boolean;
@@ -14,7 +20,7 @@ export type LabelProps = {
 } & HTMLElementProps<HTMLLabelElement>;
 
 export const Label: React.FC<LabelProps> = ({
-  visualOnly,
+  asSpan,
   children,
   className,
   required,
@@ -22,7 +28,7 @@ export const Label: React.FC<LabelProps> = ({
   cursor,
   ...restProps
 }) => {
-  const Component = visualOnly ? 'span' : 'label';
+  const Component = asSpan ? 'span' : 'label';
   const containerClassName = useComponentStyles('label', {
     base: true,
     variants: { required, size },

--- a/src/components/form/Radio/Radio.stories.tsx
+++ b/src/components/form/Radio/Radio.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Stack } from '../../layout/Stack';
 import { Radio, RadioProps } from './Radio';
 import { RadioGroup } from './RadioGroup';
 
@@ -14,9 +15,17 @@ export const Default: StoryObj<RadioProps> = {
       <>
         <label id="radio-group">Radio group</label>
         <RadioGroup aria-labelledby="radio-group">
-          <Radio name="radio-group" value="a" label="Radio a" {...props} />
-          <Radio name="radio-group" value="b" label="Radio b" />
-          <Radio name="radio-group" value="c" label="Radio c" />
+          <Stack spacing="medium">
+            <Radio name="radio-group" value="a" {...props}>
+              Radio A
+            </Radio>
+            <Radio name="radio-group" value="b">
+              Radio B
+            </Radio>
+            <Radio name="radio-group" value="c">
+              Radio C
+            </Radio>
+          </Stack>
         </RadioGroup>
       </>
     );

--- a/src/components/form/Radio/Radio.tsx
+++ b/src/components/form/Radio/Radio.tsx
@@ -2,17 +2,17 @@ import { forwardRef } from 'react';
 import { useComponentStyles } from '../../../hooks/useComponentStyles';
 import { classnames } from '../../../lib/utils/classnames';
 import { HTMLElementProps } from '../../../lib/utils/utils';
-import { Label } from '../Label/Label';
+import { Label } from '../Label';
 import * as styles from './radio.css';
 
 export type RadioProps = {
   name: string;
   value: string;
-  label?: React.ReactNode;
+  children?: React.ReactNode;
 } & HTMLElementProps<HTMLInputElement>;
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Checkbox(
-  { name, label, className, ...restProps },
+  { name, children, className, ...restProps },
   ref,
 ) {
   const containerClassName = useComponentStyles('radio', { base: true }, false);
@@ -26,14 +26,14 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Checkbox(
     </div>
   );
 
-  if (!label) {
+  if (!children) {
     return input;
   }
 
   return (
     <label className={labelClassName}>
       {input}
-      {label && <Label visualOnly>{label}</Label>}
+      <Label asSpan>{children}</Label>
     </label>
   );
 });

--- a/src/components/form/Radio/RadioGroup.tsx
+++ b/src/components/form/Radio/RadioGroup.tsx
@@ -1,20 +1,12 @@
-import { Atoms } from '../../../lib/css/atoms';
-import { Stack } from '../../layout/Stack';
-
 export type RadioGroupProps = {
   'aria-labelledby'?: string;
   children: React.ReactNode;
-  gap?: Atoms['gap'];
 };
 
-export const RadioGroup: React.FC<RadioGroupProps> = ({
-  children,
-  gap = 'medium',
-  ...restProps
-}) => {
+export const RadioGroup: React.FC<RadioGroupProps> = ({ children, ...restProps }) => {
   return (
-    <Stack tag="div" role="radiogroup" gap={gap} {...restProps}>
+    <div role="radiogroup" {...restProps}>
       {children}
-    </Stack>
+    </div>
   );
 };

--- a/src/components/layout/Stack/Stack.stories.tsx
+++ b/src/components/layout/Stack/Stack.stories.tsx
@@ -9,10 +9,10 @@ export default {
   title: 'Layout/Stack',
   component: Stack,
   args: {
-    gap: 'small',
+    spacing: 'small',
   },
   argTypes: {
-    gap: {
+    spacing: {
       name: 'gap',
       type: 'string',
       control: 'select',
@@ -38,7 +38,7 @@ export const Default: StoryObj<StackProps> = {
   },
 
   args: {
-    gap: ['small', 'medium', 'large'],
+    spacing: ['small', 'medium', 'large'],
     children: (
       <>
         <Box backgroundColor="danger" padding="small">
@@ -66,7 +66,7 @@ export const List: StoryObj<StackProps> = {
   },
 
   args: {
-    gap: ['small', 'medium', 'large'],
+    spacing: ['small', 'medium', 'large'],
     tag: 'ol',
     children: (
       <>

--- a/src/components/layout/Stack/Stack.tsx
+++ b/src/components/layout/Stack/Stack.tsx
@@ -8,7 +8,7 @@ export type StackProps = {
   children: React.ReactNode;
   className?: string;
   display?: ResponsiveDisplayFlex;
-  gap: Atoms['gap'];
+  spacing: Atoms['gap'];
   style?: React.CSSProperties;
   role?: React.AriaRole;
   /**
@@ -22,19 +22,19 @@ export const Stack: React.FC<StackProps> = ({
   tag: Tag = 'div',
   display = 'flex',
   children,
-  gap,
+  spacing,
   alignX,
   ...restProps
 }) => {
   if (process.env.NODE_ENV === 'development' && restProps.start !== undefined && Tag !== 'ol') {
-    console.warn('Stack: start prop is only valid when tag="ol"');
+    console.warn('Stack: "start" prop is only valid with tag="ol"');
   }
 
   return (
     <Box
       asChild
       display={display}
-      gap={gap}
+      gap={spacing}
       flexDirection="column"
       alignItems={alignX ? alignItemsMap[alignX] : undefined}
       {...restProps}

--- a/src/components/overlay/Dialog/Dialog.stories.tsx
+++ b/src/components/overlay/Dialog/Dialog.stories.tsx
@@ -47,7 +47,7 @@ export const Default: StoryObj<DialogProps> = {
   args: {
     children: (
       <>
-        <Stack gap="medium">
+        <Stack spacing="medium">
           <Heading level={2}>Hello world!</Heading>
           <Text tag="p" fontSize="small">
             This is a dialog.
@@ -57,7 +57,7 @@ export const Default: StoryObj<DialogProps> = {
             <NestedDialog>Two</NestedDialog>
           </NestedDialog>
           <form onSubmit={(event) => event.preventDefault()}>
-            <Stack gap="small" alignX="center">
+            <Stack spacing="small" alignX="center">
               {/* <Input name="firstName" label="First name" autoFocus /> */}
               <Button type="submit">Submit</Button>
             </Stack>
@@ -95,7 +95,7 @@ export const Play: StoryObj<DialogProps> = {
   args: {
     children: (
       <>
-        <Stack gap="medium">
+        <Stack spacing="medium">
           <Heading level={2}>Hello world</Heading>
           <Button type="submit">Close Dialog</Button>
         </Stack>

--- a/src/components/typography/Heading/heading.stories.tsx
+++ b/src/components/typography/Heading/heading.stories.tsx
@@ -45,7 +45,7 @@ export const Default: StoryObj<HeadingProps> = {
 };
 
 const TemplateAllHeadings: StoryFn<typeof Heading> = (args) => (
-  <Stack gap="medium">
+  <Stack spacing="medium">
     <Heading {...args} level={1}>
       Heading 1
     </Heading>


### PR DESCRIPTION
- Renamed prop `gap` to `spacing` in Stack
- Renamed prop `visualOnly` to `asSpan` in Label
- Removed Stack from RadioGroup for more flexibility how to render child elements